### PR TITLE
Enable manual nightly evaluations

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,7 @@ name: Nightly
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   eval:


### PR DESCRIPTION
## Summary
- allow manual invocation of the nightly workflow

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686246f78f3c8329ade98dc4f2261d99