### PR TITLE
Enable manual nightly evaluations

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,7 @@ name: Nightly
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   eval:
@@ -20,7 +21,7 @@ jobs:
         run: |
           python -m promptgym.evaluation.runner --agent ${{matrix.agent}} --seed ${{matrix.seed}} --outdir runs
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: runs-${{matrix.agent}}-${{matrix.seed}}
           path: runs


### PR DESCRIPTION
## Summary
- allow manual invocation of the nightly workflow
- bump upload-artifact action to v4 as older versions are deprecated

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686246f78f3c8329ade98dc4f2261d99